### PR TITLE
Remove related videos on narrow view

### DIFF
--- a/distraction-free-youtube.user.js
+++ b/distraction-free-youtube.user.js
@@ -23,6 +23,7 @@
         distraction('Top left button (expander)', '#guide-button', 'remove'),
         distraction('Left buttons (trending, subscriptions', 'ytd-mini-guide-renderer', 'remove'),
         distraction('Related videos', '#secondary', 'remove'),
+        distraction('Related videos (narrow width)', '#chips', 'remove'),
         distraction('Video browser (home page)', 'ytd-browse', 'remove'),
         distraction('Comments', 'ytd-comments', 'remove'),
         distraction('App Drawer', '#guide', 'remove'),


### PR DESCRIPTION
When the window is narrow, youtube switches to a different layout, and a different selector `#chips` then seems to be needed in order to remove the related videos. There might be a better way of doing this, but this worked for me so I thought I'd share. Thanks for this script!